### PR TITLE
Resource.get() completely broken.

### DIFF
--- a/lib/dyn/traffic/resource.rb
+++ b/lib/dyn/traffic/resource.rb
@@ -75,7 +75,7 @@ module Dyn
         elsif fqdn
           results = @dyn.get("#{resource_path}/#{fqdn}")
           raw_rr_list = results.map do |record|
-            if (record =~ /^#{resource_path(true)}\/#{Regexp.escape(fqdn)}\/(\d+)$/)
+            if (record =~ /^#{resource_path(:full)}\/#{Regexp.escape(fqdn)}\/(\d+)$/)
               self.get(fqdn, $1)
             else
               record


### PR DESCRIPTION
Working with this ruby lib for the first time today and quite quickly ran in to a couple of issues when trying to get details of a CNAME.

Here's a pull request to fix a couple of the issues - seems to be working nicely since implementing the patch.
