### PR TITLE
Added ability to discard the pending change set from the session.

### DIFF
--- a/lib/dyn/traffic.rb
+++ b/lib/dyn/traffic.rb
@@ -91,6 +91,11 @@ module Dyn
         zone.publish
       end
 
+      # for convenience...
+      def discard_change_set
+        zone.discard_change_set
+      end
+
       ##
       # Zone attribute setter
       ##

--- a/lib/dyn/traffic/base.rb
+++ b/lib/dyn/traffic/base.rb
@@ -33,6 +33,16 @@ module Dyn
         @dyn.put("Zone/#{@zone}", { "publish" => true })
       end
 
+      # Discard any pending changes in the session - required if you don't with to persist changes.
+      #
+      # See: https://help.dynect.net/delete-zone-change-set-api/
+      #
+      # @param [String] The zone to discard changes for - if one is provided when instantiated, we use that.
+      # @return [Hash] The dynect API response
+      def discard_change_set
+        @dyn.delete("ZoneChanges/#{@zone}")
+      end
+
       # Freeze the zone.
       #
       # See: https://manage.dynect.net/help/docs/api2/rest/resources/Zone.html
@@ -52,6 +62,7 @@ module Dyn
       def thaw
         @dyn.put("Zone/#{@zone}", { "thaw" => true })
       end
+
     end
   end
 end


### PR DESCRIPTION
Whilst working with the lib I've found it quite often useful to be able to discard pending changes as part of a rescue cleanup if something happens in the app between the creation of the record and publication.

The API allows for this https://help.dynect.net/delete-zone-change-set-api/ so I have added 'discard_change_set' as a feature of the lib.
