### PR TITLE
Add zone.get_change_set to check on pending changes to a zone

### DIFF
--- a/lib/dyn/traffic/base.rb
+++ b/lib/dyn/traffic/base.rb
@@ -63,6 +63,15 @@ module Dyn
         @dyn.put("Zone/#{@zone}", { "thaw" => true })
       end
 
+      # Show pending changes to zone
+      #
+      # See: https://help.dyn.com/get-zone-changeset-api/
+      #
+      # @param [String] The zone which we want to see the changes for - if one is provided when instantiated, we use that.
+      # @return [Hash] The dynect API response
+      def get_change_set
+        @dyn.get("ZoneChanges/#{@zone}")
+      end
     end
   end
 end


### PR DESCRIPTION
Simple wrapper for the `ZoneChanges` API call. 

Super useful when doing larger changes to check that amounts etc match up to expected.