### PR TITLE
Avoid JSON::ParserError

### DIFF
--- a/lib/dyn/messaging.rb
+++ b/lib/dyn/messaging.rb
@@ -138,8 +138,8 @@ module Dyn
           response.body
         end
 
-        response = JSON.parse(response_body || '{}')
-        
+        response = response_body && response_body.length >= 2 ? JSON.parse(response_body) : {}
+
         if (response["response"] && response["response"]["status"] == 200)
           response["response"]["data"]
         else

--- a/lib/dyn/traffic.rb
+++ b/lib/dyn/traffic.rb
@@ -204,7 +204,7 @@ module Dyn
           response.body.sub!('/REST/','') 
           response = get(response.body)
         end
-        parse_response(JSON.parse(response.body || '{}'))
+        parse_response(response.body && response.body.length >= 2 ? JSON.parse(response.body) : {})
       end
 
       def parse_response(response)


### PR DESCRIPTION
In some cases the API response is less than two characters, which is invalid JSON. This now returns an empty hash when being parsed, instead of raising an exception.