### PR TITLE
GSLB: add status information about hosts in host_list

### DIFF
--- a/lib/dyn/traffic/gslb.rb
+++ b/lib/dyn/traffic/gslb.rb
@@ -10,9 +10,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ module Dyn
         @ttl          = options[:ttl] || 30
         @host_list    = options[:host_list] || {}
         @contact_nick = options[:contact_nick] || 'owner'
-      
+
         @region_code  = options[:region_code] || 'global'
         @monitor      = options[:monitor] || {}
         @serve_count  = options[:serve_count] || 1
@@ -110,7 +110,8 @@ module Dyn
                                       :address => h["address"],
                                       :label => h["label"],
                                       :weight => h["weight"],
-                                      :serve_mode => h["serve_mode"]
+                                      :serve_mode => h["serve_mode"],
+                                      :status => h["status"]
                                       }
           end
           Dyn::Traffic::GSLB.new(@dyn, results["zone"], {


### PR DESCRIPTION
GSLB: add status information about hosts in host_list

The status of a specific host should be added to the host_list hash as it is important information when dealing with GSLB configurations.
